### PR TITLE
[Feat] - Add splash screen

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -7,7 +7,7 @@ import { theme } from "./src/styles";
 import styled from "styled-components/native";
 import { View, Text } from "react-native";
 import { Footer } from "./src/components";
-import { Home, Map, Profile, Report, ReportDetails, ReportDone } from "./src/pages";
+import { Home, Map, Profile, Report, ReportDetails, ReportDone, Splash } from "./src/pages";
 
 type TabType = "map" | "home" | "profile" | "report";
 
@@ -54,6 +54,7 @@ export default function App() {
     "Pinkfong-Baby-Shark-Bold": require("./assets/fonts/Pinkfong Baby Shark Font_ Bold.ttf"),
   });
 
+  const [showSplash, setShowSplash] = useState(true);
   const [activeTab, setActiveTab] = useState<TabType>("home");
   const [showReportDetails, setShowReportDetails] = useState(false);
   const [showReportDone, setShowReportDone] = useState(false);
@@ -146,6 +147,17 @@ export default function App() {
       <View style={{ flex: 1, justifyContent: "center", alignItems: "center" }}>
         <Text>로딩 중...</Text>
       </View>
+    );
+  }
+
+  if (showSplash) {
+    return (
+      <SafeAreaProvider>
+        <ThemeProvider theme={theme}>
+          <Splash onFinish={() => setShowSplash(false)} />
+          <StatusBar style="light" />
+        </ThemeProvider>
+      </SafeAreaProvider>
     );
   }
 

--- a/src/pages/Splash/Splash.tsx
+++ b/src/pages/Splash/Splash.tsx
@@ -1,0 +1,177 @@
+import React, { useEffect, useRef } from "react";
+import { Animated } from "react-native";
+import styled from "styled-components/native";
+import Svg, { Circle, Path } from "react-native-svg";
+
+const SplashContainer = styled(Animated.View)`
+  flex: 1;
+  background-color: #0b1620;
+  align-items: center;
+  justify-content: center;
+`;
+
+const LogoContainer = styled(Animated.View)`
+  align-items: center;
+  justify-content: center;
+  margin-bottom: 24px;
+`;
+
+const LogoWrapper = styled(Animated.View)`
+  width: 228px;
+  height: 179px;
+  align-items: center;
+  justify-content: center;
+`;
+
+const IeumText = styled(Animated.Text)`
+  font-family: ${(props) => props.theme.fonts.bold};
+  font-size: 32px;
+  color: #68d0c6;
+  margin-top: 24px;
+  letter-spacing: 2px;
+`;
+
+const MobicomText = styled(Animated.Text)`
+  position: absolute;
+  bottom: 40px;
+  font-family: ${(props) => props.theme.fonts.primary};
+  font-size: 14px;
+  color: #ffffff;
+  letter-spacing: 0.5px;
+`;
+
+interface SplashProps {
+  onFinish?: () => void;
+}
+
+export const Splash = ({ onFinish }: SplashProps) => {
+  const fadeAnim = useRef(new Animated.Value(0)).current;
+  const scaleAnim = useRef(new Animated.Value(0.8)).current;
+  const textFadeAnim = useRef(new Animated.Value(0)).current;
+  const mobicomFadeAnim = useRef(new Animated.Value(0)).current;
+  const containerFadeAnim = useRef(new Animated.Value(1)).current;
+
+  useEffect(() => {
+    // 로고 페이드 인 + 스케일 애니메이션
+    Animated.parallel([
+      Animated.timing(fadeAnim, {
+        toValue: 1,
+        duration: 800,
+        useNativeDriver: true,
+      }),
+      Animated.spring(scaleAnim, {
+        toValue: 1,
+        tension: 50,
+        friction: 7,
+        useNativeDriver: true,
+      }),
+    ]).start();
+
+    // 텍스트 페이드 인 애니메이션 (로고 이후)
+    Animated.sequence([
+      Animated.delay(400),
+      Animated.timing(textFadeAnim, {
+        toValue: 1,
+        duration: 600,
+        useNativeDriver: true,
+      }),
+    ]).start();
+
+    // mobicom 텍스트 페이드 인
+    Animated.sequence([
+      Animated.delay(600),
+      Animated.timing(mobicomFadeAnim, {
+        toValue: 1,
+        duration: 600,
+        useNativeDriver: true,
+      }),
+    ]).start();
+
+    // 스플래시 종료 시 페이드 아웃
+    const timer = setTimeout(() => {
+      Animated.timing(containerFadeAnim, {
+        toValue: 0,
+        duration: 500,
+        useNativeDriver: true,
+      }).start(() => {
+        if (onFinish) {
+          onFinish();
+        }
+      });
+    }, 2000);
+
+    return () => clearTimeout(timer);
+  }, [
+    onFinish,
+    fadeAnim,
+    scaleAnim,
+    textFadeAnim,
+    mobicomFadeAnim,
+    containerFadeAnim,
+  ]);
+
+  return (
+    <SplashContainer
+      style={{
+        opacity: containerFadeAnim,
+      }}
+    >
+      <LogoContainer
+        style={{
+          opacity: fadeAnim,
+        }}
+      >
+        <LogoWrapper
+          style={{
+            transform: [{ scale: scaleAnim }],
+          }}
+        >
+          <Svg width="228" height="179" viewBox="0 0 228 179" fill="none">
+            <Circle
+              cx="29.5"
+              cy="117.5"
+              r="29"
+              fill="#68D0C6"
+              stroke="#68D0C6"
+            />
+            <Circle
+              cx="167.5"
+              cy="29.5"
+              r="29"
+              fill="#68D0C6"
+              stroke="#68D0C6"
+            />
+            <Path
+              d="M5 173.5C127.5 173.5 99.5 72 214.5 72"
+              stroke="#68D0C6"
+              strokeWidth="10"
+              strokeLinecap="round"
+            />
+            <Path
+              d="M151.558 90.7102C150.654 86.1722 152.974 81.5843 157.225 79.757C176.976 71.2671 190.951 68.2144 211.944 68.7694C216.488 68.8895 220.27 72.2188 221.157 76.6762L224.273 92.3302C225.63 99.1496 219.778 105.188 212.85 104.6C196.056 103.175 183.925 105.14 170.441 112.212C164.055 115.561 155.858 112.318 154.451 105.245L151.558 90.7102Z"
+              fill="#68D0C6"
+            />
+            <Path
+              d="M151.558 90.7102C150.654 86.1722 152.974 81.5843 157.225 79.757C176.976 71.2671 190.951 68.2144 211.944 68.7694C216.488 68.8895 220.27 72.2188 221.157 76.6762L224.273 92.3302C225.566 98.8291 220.312 104.619 213.819 104.64C213.174 104.642 212.524 104.636 211.883 104.705C196.06 106.409 184.734 107.179 171.517 114.111C165.131 117.46 155.858 112.318 154.451 105.245L151.558 90.7102Z"
+              fill="#68D0C6"
+            />
+          </Svg>
+        </LogoWrapper>
+        <IeumText
+          style={{
+            opacity: textFadeAnim,
+          }}
+        >
+          IEUM
+        </IeumText>
+      </LogoContainer>
+      <MobicomText
+        style={{
+          opacity: mobicomFadeAnim,
+        }}
+      >
+        mobicom
+      </MobicomText>
+    </SplashContainer>
+  );
+};

--- a/src/pages/Splash/index.tsx
+++ b/src/pages/Splash/index.tsx
@@ -1,0 +1,2 @@
+export { Splash } from "./Splash";
+

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -4,3 +4,4 @@ export { Profile } from "./Profile";
 export { Report } from "./Report";
 export { ReportDetails } from "./Report";
 export { ReportDone } from "./Report";
+export { Splash } from "./Splash";


### PR DESCRIPTION
## 💡 Issue Number

None

## Description

- 스플래시 화면 페이지 구현
- 애니메이션이 포함된 스플래시 화면 (로고 페이드 인 + 스케일, 텍스트 순차 페이드 인)
- SVG를 사용한 IEUM 로고 표시
- 2초 후 자동 페이드 아웃 및 메인 화면 전환
- App.tsx에 스플래시 화면 통합 및 상태 관리 추가

## 🔧 변경 타입

<!-- 해당하는 항목에 x를 표시해주세요 -->

- [x] 기능 추가
- [ ] 버그 수정
- [ ] 코드 리팩토링
- [x] UI/UX 개선
- [ ] 문서 업데이트
- [ ] 의존성 업데이트
- [x] 파일 혹은 폴더 수정
- [ ] 파일 혹은 폴더 삭제
- [ ] 기타 (아래에 설명)

## ✅ Reviewer

<!-- 팀원들은 확인 후 체크해주세요.  -->

- [x] @yxxunseo 
- [ ]
- [ ]

## 💬 Comment

<!-- 리뷰어가 알아야 할 추가 정보가 있다면 작성해주세요 -->

- React Native Animated API를 사용하여 부드러운 애니메이션 효과를 구현했습니다
- 로고는 SVG 컴포넌트로 직접 구현하여 벡터 그래픽의 선명함을 유지합니다
- useNativeDriver를 사용하여 애니메이션 성능을 최적화했습니다
- 스플래시 화면은 앱 시작 시 자동으로 표시되며, onFinish 콜백을 통해 메인 화면으로 전환됩니다
